### PR TITLE
chore: dockerize nuxt app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
 # Multi-stage Dockerfile for Nuxt 4 + pnpm
 
 # --- Build Stage ---
-FROM node:20-alpine AS build
+FROM node:18-alpine AS build
 WORKDIR /app
+# Install pnpm via corepack
+RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 COPY . .
-RUN pnpm run build
+RUN pnpm build
 
 # --- Production Stage ---
-FROM node:20-alpine AS runner
+FROM node:18-alpine AS runner
 WORKDIR /app
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOST=0.0.0.0
 COPY --from=build /app/.output ./.output
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/node_modules ./node_modules
 EXPOSE 3000
-CMD ["pnpm", "start"]
+CMD ["node", ".output/server/index.mjs"]

--- a/railway.json
+++ b/railway.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "DOCKER"
   },
   "deploy": {
-    "startCommand": "pnpm start",
     "healthcheckPath": "/",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build and run Nuxt app with pnpm and Node 18
- configure Railway to use Docker builder instead of Nixpacks

## Testing
- `pnpm build` (fails: Error when checking client information)
- `pnpm start` (fails: Cannot find nitro.json – run build first)


------
https://chatgpt.com/codex/tasks/task_e_6891e0a0e714832581514ccb4ae5ee35